### PR TITLE
fix(adapter): do not skip "it" block when description is empty

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -74,7 +74,13 @@ class JasmineAdapter {
                     // specFn will be replaced by wdio-sync and will always return a promise
                     return specFn.call(this).then(() => done(), (e) => done.fail(e))
                 }
-                const newArgs = [specTitle, patchedOrigFn, retryCnt].filter(a => Boolean(a))
+                const newArgs = [specTitle, patchedOrigFn, retryCnt].filter(a => {
+                    if (a === '') {
+                        return true;
+                    } else {
+                        return Boolean(a);
+                    }
+                });
 
                 if (!specFn) {
                     return origFn(specTitle)


### PR DESCRIPTION
- The it block `it('', () => {});` is skipped because the description is
an empty string. The filter function casts the empty string to a boolean
which is false and should be true.

closes #130