### PR TITLE
Add stopOnSpecFailure support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,26 @@ Optional pattern to selectively select it/describe cases to run from spec files.
 Type: `RegExp | string`<br>
 Default: undefined
 
-## invertGrep
+### invertGrep
 Inverts 'grep' matches
 
 Type: `Boolean`<br>
 Default: false
 
-## cleanStack
+### cleanStack
 Cleans up stack trace and removes all traces of node module packages
 
 Type: `Boolean`<br>
 Default: true  
 
-## random  
+### random  
 Run specs in semi-random order  
+
+Type: `Boolean`<br>
+Default: `false`
+
+### stopOnSpecFailure
+Stops spec execution on first fail (other specs continue running). Requires Jasmine 3.2+
 
 Type: `Boolean`<br>
 Default: `false`

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Type: `Boolean`<br>
 Default: `false`
 
 ### stopOnSpecFailure
-Stops spec execution on first fail (other specs continue running). Requires Jasmine 3.2+
+Stops spec execution on first fail (other specs continue running)
 
 Type: `Boolean`<br>
 Default: `false`

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -56,6 +56,15 @@ class JasmineAdapter {
             return true
         }
 
+        const stopOnSpecFailure = this.getStopOnSpecFailure()
+        if (stopOnSpecFailure) {
+            try {
+                jasmine.getEnv().stopOnSpecFailure(stopOnSpecFailure)
+            } catch (e) {
+                console.log('Warning: installed version of Jasmine doesn\'t support stopOnSpecFailure')
+            }
+        }
+
         /**
          * enable expectHandler
          */
@@ -232,6 +241,10 @@ class JasmineAdapter {
         }
 
         return this.expectationResultHandler(origHandler)
+    }
+
+    getStopOnSpecFailure () {
+        return !!this.jasmineNodeOpts.stopOnSpecFailure
     }
 
     expectationResultHandler (origHandler) {

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -56,14 +56,11 @@ class JasmineAdapter {
             return true
         }
 
-        const stopOnSpecFailure = this.getStopOnSpecFailure()
-        if (stopOnSpecFailure) {
-            try {
-                jasmine.getEnv().stopOnSpecFailure(stopOnSpecFailure)
-            } catch (e) {
-                console.log('Warning: installed version of Jasmine doesn\'t support stopOnSpecFailure')
-            }
-        }
+        /**
+         * Set whether to stop suite execution when a spec fails
+         */
+        const stopOnSpecFailure = !!this.jasmineNodeOpts.stopOnSpecFailure
+        jasmine.getEnv().stopOnSpecFailure(stopOnSpecFailure)
 
         /**
          * enable expectHandler
@@ -241,10 +238,6 @@ class JasmineAdapter {
         }
 
         return this.expectationResultHandler(origHandler)
-    }
-
-    getStopOnSpecFailure () {
-        return !!this.jasmineNodeOpts.stopOnSpecFailure
     }
 
     expectationResultHandler (origHandler) {

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -92,6 +92,19 @@ describe('jasmine adapter unit tests', () => {
             })
         })
 
+        describe('stopOnSpecFailure', () => {
+            it('disables stop spec on first failure by default', () => {
+                adapter = new JasmineAdapter(1, config, specs, caps)
+                adapter.getStopOnSpecFailure().should.be.false()
+            })
+
+            it('enables stop spec on first failure if set', () => {
+                config.jasmineNodeOpts = { stopOnSpecFailure: true }
+                adapter = new JasmineAdapter(1, config, specs, caps)
+                adapter.getStopOnSpecFailure().should.be.true()
+            })
+        })
+
         describe('getExpectationResultHandler', () => {
             it('should return default jasmine expectationResultHandler if nothing set', () => {
                 adapter = new JasmineAdapter(1, config, specs, caps)

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -92,19 +92,6 @@ describe('jasmine adapter unit tests', () => {
             })
         })
 
-        describe('stopOnSpecFailure', () => {
-            it('disables stop spec on first failure by default', () => {
-                adapter = new JasmineAdapter(1, config, specs, caps)
-                adapter.getStopOnSpecFailure().should.be.false()
-            })
-
-            it('enables stop spec on first failure if set', () => {
-                config.jasmineNodeOpts = { stopOnSpecFailure: true }
-                adapter = new JasmineAdapter(1, config, specs, caps)
-                adapter.getStopOnSpecFailure().should.be.true()
-            })
-        })
-
         describe('getExpectationResultHandler', () => {
             it('should return default jasmine expectationResultHandler if nothing set', () => {
                 adapter = new JasmineAdapter(1, config, specs, caps)


### PR DESCRIPTION
Since Jasmine 3.2, useful `stopOnSpecFailure` option became available: [documentation](https://jasmine.github.io/api/3.2/Env.html)

Would be really nice to support this feature.

**stopOnSpecFailure(value)**

Set whether to stop suite execution when a spec fails

Parameters:

Name | Type | Description
-- | -- | --
value | Boolean | Whether to stop suite execution when a spec fails



